### PR TITLE
Hotfix 2025-06-13

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -12,6 +12,7 @@ dont_starve_compatible = false
 reign_of_giants_compatible = false
 dst_compatible = true
 api_version = 10
+priority = -1
 
 local function AddOption(name,label,hover,options,default)
     return  {


### PR DESCRIPTION
Changed mod priority to -1 to prevent a game crash when 'Status Announcements' mod is enabled.